### PR TITLE
debian images install php-gd so image generation works

### DIFF
--- a/ja/Dockerfile
+++ b/ja/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       php5 \
       libapache2-mod-php5 \
       php5-cli \
-      php-gd \
+      php5-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/ja/Dockerfile
+++ b/ja/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
       php5 \
       libapache2-mod-php5 \
       php5-cli \
+      php-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
       php5-common \
       libapache2-mod-php5 \
       php5-cli \
-      php-gd \
+      php5-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       php5-common \
       libapache2-mod-php5 \
       php5-cli \
+      php-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/test-dev-ja/Dockerfile
+++ b/test-dev-ja/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       php5 \
       libapache2-mod-php5 \
       php5-cli \
-      php-gd \
+      php5-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/test-dev-ja/Dockerfile
+++ b/test-dev-ja/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
       php5 \
       libapache2-mod-php5 \
       php5-cli \
+      php-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update \
       php5 \
       libapache2-mod-php5 \
       php5-cli \
-      php-gd \
+      php5-gd \
       php5-mysql \
       mysql-server \
       mysql-client \

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update \
       php5 \
       libapache2-mod-php5 \
       php5-cli \
+      php-gd \
       php5-mysql \
       mysql-server \
       mysql-client \


### PR DESCRIPTION
Current docker images complain about missing ImageMagick or GD.
