### PR TITLE
ruby and node ( on debian )

### DIFF
--- a/ja/Dockerfile
+++ b/ja/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update \
       supervisor \
       ca-certificates \
       vim \
+      ruby \
+      ruby-dev \
+      wget \
+      build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 #
@@ -25,6 +29,25 @@ RUN apt-get update \
 RUN mv /etc/apache2/sites-available/default /etc/apache2/sites-available/default.dist
 ADD apache2-default /etc/apache2/sites-available/default
 RUN a2enmod rewrite
+
+# Install Node.js
+RUN \
+  cd /tmp && \
+  wget http://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz && \
+  tar xvzf node-v0.10.32.tar.gz && \
+  rm -f node-v0.10.32.tar.gz && \
+  cd node-v* && \
+  ./configure && \
+  CXX="g++ -Wno-unused-local-typedefs" make && \
+  CXX="g++ -Wno-unused-local-typedefs" make install && \
+  cd /tmp && \
+  rm -rf /tmp/node-v* && \
+  npm install -g npm && \
+  echo -e '\n# Node.js\nexport PATH="node_modules/.bin:$PATH"' >> /root/.bashrc
+
+# Install Node modules
+RUN \
+  npm install -g grunt-cli gulp webpack bower
 
 #
 # Install WP-CLI

--- a/jessie/Dockerfile
+++ b/jessie/Dockerfile
@@ -18,6 +18,10 @@ RUN apt-get update \
       supervisor \
       ca-certificates \
       vim \
+      ruby \
+      ruby-dev \
+      wget \
+      build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 #
@@ -26,6 +30,25 @@ RUN apt-get update \
 RUN mv /etc/apache2/apache2.conf /etc/apache2/apache2.conf.dist
 ADD apache2.conf /etc/apache2/apache2.conf
 RUN a2enmod rewrite
+
+# Install Node.js
+RUN \
+  cd /tmp && \
+  wget http://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz && \
+  tar xvzf node-v0.10.32.tar.gz && \
+  rm -f node-v0.10.32.tar.gz && \
+  cd node-v* && \
+  ./configure && \
+  CXX="g++ -Wno-unused-local-typedefs" make && \
+  CXX="g++ -Wno-unused-local-typedefs" make install && \
+  cd /tmp && \
+  rm -rf /tmp/node-v* && \
+  npm install -g npm && \
+  echo -e '\n# Node.js\nexport PATH="node_modules/.bin:$PATH"' >> /root/.bashrc
+
+# Install Node modules
+RUN \
+  npm install -g grunt-cli gulp webpack bower
 
 #
 # Install WP-CLI

--- a/test-dev-ja/Dockerfile
+++ b/test-dev-ja/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update \
       supervisor \
       ca-certificates \
       vim \
+      ruby \
+      ruby-dev \
+      wget \
+      build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 #
@@ -25,6 +29,25 @@ RUN apt-get update \
 RUN mv /etc/apache2/sites-available/default /etc/apache2/sites-available/default.dist
 ADD apache2-default /etc/apache2/sites-available/default
 RUN a2enmod rewrite
+
+# Install Node.js
+RUN \
+  cd /tmp && \
+  wget http://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz && \
+  tar xvzf node-v0.10.32.tar.gz && \
+  rm -f node-v0.10.32.tar.gz && \
+  cd node-v* && \
+  ./configure && \
+  CXX="g++ -Wno-unused-local-typedefs" make && \
+  CXX="g++ -Wno-unused-local-typedefs" make install && \
+  cd /tmp && \
+  rm -rf /tmp/node-v* && \
+  npm install -g npm && \
+  echo -e '\n# Node.js\nexport PATH="node_modules/.bin:$PATH"' >> /root/.bashrc
+
+# Install Node modules
+RUN \
+  npm install -g grunt-cli gulp webpack bower
 
 #
 # Install WP-CLI

--- a/wheezy/Dockerfile
+++ b/wheezy/Dockerfile
@@ -17,6 +17,10 @@ RUN apt-get update \
       supervisor \
       ca-certificates \
       vim \
+      ruby \
+      ruby-dev \
+      wget \
+      build-essential \
     && rm -rf /var/lib/apt/lists/*
 
 #
@@ -25,6 +29,25 @@ RUN apt-get update \
 RUN mv /etc/apache2/sites-available/default /etc/apache2/sites-available/default.dist
 ADD apache2-default /etc/apache2/sites-available/default
 RUN a2enmod rewrite
+
+# Install Node.js
+RUN \
+  cd /tmp && \
+  wget http://nodejs.org/dist/v0.10.32/node-v0.10.32.tar.gz && \
+  tar xvzf node-v0.10.32.tar.gz && \
+  rm -f node-v0.10.32.tar.gz && \
+  cd node-v* && \
+  ./configure && \
+  CXX="g++ -Wno-unused-local-typedefs" make && \
+  CXX="g++ -Wno-unused-local-typedefs" make install && \
+  cd /tmp && \
+  rm -rf /tmp/node-v* && \
+  npm install -g npm && \
+  echo -e '\n# Node.js\nexport PATH="node_modules/.bin:$PATH"' >> /root/.bashrc
+
+# Install Node modules
+RUN \
+  npm install -g grunt-cli gulp webpack bower
 
 #
 # Install WP-CLI


### PR DESCRIPTION
As I want to use WordMove and gulp on Wocker,
I added the installation of ruby and node to the Dockerfile.
Only devian works because CentOS fails with an error in the dockerhub build test program.
I don't know how to build an environment.

---

WordMoveとgulpなどをWockerで利用したくて、
rubyとnodeをインストールするようにDockerfileに追記しました。
dockerhubのビルドテストでCentOSはエラーですので、devian版だけ動作します。
環境構築どうすればよかったかわからず。
