### PR TITLE
Enable remote debug

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -34,6 +34,11 @@ RUN echo "ServerName localhost" >> /etc/apache2/apache2.conf \
   && a2enmod rewrite
 
 #
+# Xdebug settings for remote debug
+#
+ADD xdebug-remote-debug.ini /etc/php/7.3/apache2/conf.d/20-xdebug.ini
+
+#
 # php.ini settings
 #
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.3/apache2/php.ini \

--- a/apache/xdebug-remote-debug.ini
+++ b/apache/xdebug-remote-debug.ini
@@ -1,0 +1,9 @@
+zend_extension=xdebug.so
+xdebug.remote_enable=1
+;xdebug.remote_autostart=1
+xdebug.remote_handler=dbgp
+xdebug.remote_mode=req
+xdebug.remote_port=9000
+xdebug.remote_host=10.0.2.2 ;VirtualBox
+xdebug.remote_connect_back = 0
+;xdebug.remote_log=/tmp/xdebug.log

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -42,6 +42,11 @@ RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.3/fpm/pool.d/www.conf \
   && sed -i -e "s/^;listen.mode =.*/listen.mode = 0660/" /etc/php/7.3/fpm/pool.d/www.conf
 
 #
+# Xdebug settings for remote debug
+#
+ADD xdebug-remote-debug.ini /etc/php/7.3/fpm/conf.d/20-xdebug.ini
+
+#
 # php.ini settings
 #
 RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.3/fpm/php.ini \

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -9,17 +9,17 @@ RUN apt-get update \
   && apt-get clean \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     nginx \
-    php7.0 \
-    php7.0-bz \
-    php7.0-cli \
-    php7.0-curl \
-    php7.0-fpm \
-    php7.0-gd \
-    php7.0-mbstring \
-    php7.0-mysql \
-    php7.0-xdebug \
-    php7.0-xml \
-    php7.0-zip \
+    php7.3 \
+    php7.3-bz \
+    php7.3-cli \
+    php7.3-curl \
+    php7.3-fpm \
+    php7.3-gd \
+    php7.3-mbstring \
+    php7.3-mysql \
+    php7.3-xdebug \
+    php7.3-xml \
+    php7.3-zip \
   && rm -rf /var/lib/apt/lists/*
 
 #
@@ -35,20 +35,21 @@ RUN sed -i -e "s#root /var/www/html;#root /var/www/wordpress/;#" /etc/nginx/site
 #
 # PHP-FPM settings
 #
-RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
-  && sed -i -e "s/^group = .*/group = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
-  && sed -i -e "s/^listen.owner =.*/listen.owner = wocker/" /etc/php/7.0/fpm/pool.d/www.conf \
-  && sed -i -e "s/^listen.group =.*/listen.group = wocker/" /etc/php/7.0/fpm/pool.d/www.conf
+RUN sed -i -e "s/^user =.*/user = wocker/" /etc/php/7.3/fpm/pool.d/www.conf \
+  && sed -i -e "s/^group = .*/group = wocker/" /etc/php/7.3/fpm/pool.d/www.conf \
+  && sed -i -e "s/^listen.owner =.*/listen.owner = wocker/" /etc/php/7.3/fpm/pool.d/www.conf \
+  && sed -i -e "s/^listen.group =.*/listen.group = wocker/" /etc/php/7.3/fpm/pool.d/www.conf \
+  && sed -i -e "s/^;listen.mode =.*/listen.mode = 0660/" /etc/php/7.3/fpm/pool.d/www.conf
 
 #
 # php.ini settings
 #
-RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.0/fpm/php.ini \
-  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/mailhog sendmail#" /etc/php/7.0/fpm/php.ini \
-  && service php7.0-fpm start
+RUN sed -i -e "s/^upload_max_filesize.*/upload_max_filesize = 32M/" /etc/php/7.3/fpm/php.ini \
+  && sed -i -e "s/^post_max_size.*/post_max_size = 64M/" /etc/php/7.3/fpm/php.ini \
+  && sed -i -e "s/^display_errors.*/display_errors = On/" /etc/php/7.3/fpm/php.ini \
+  && sed -i -e "s/^;mbstring.internal_encoding.*/mbstring.internal_encoding = UTF-8/" /etc/php/7.3/fpm/php.ini \
+  && sed -i -e "s#^;sendmail_path.*#sendmail_path = /usr/local/bin/mailhog sendmail#" /etc/php/7.3/fpm/php.ini \
+  && service php7.3-fpm start
 
 #
 # MariaDB settings & install WordPress

--- a/nginx/supervisord.conf
+++ b/nginx/supervisord.conf
@@ -16,7 +16,7 @@ serverurl=unix://var/tmp/supervisor.sock
 command=/usr/sbin/nginx
 
 [program:php-fpm]
-command=php-fpm7.0
+command=php-fpm7.3
 
 [program:mysql]
 command=/usr/bin/mysqld_safe

--- a/nginx/xdebug-remote-debug.ini
+++ b/nginx/xdebug-remote-debug.ini
@@ -1,0 +1,9 @@
+zend_extension=xdebug.so
+xdebug.remote_enable=1
+;xdebug.remote_autostart=1
+xdebug.remote_handler=dbgp
+xdebug.remote_mode=req
+xdebug.remote_port=9000
+xdebug.remote_host=10.0.2.2 ;VirtualBox
+xdebug.remote_connect_back = 0
+;xdebug.remote_log=/tmp/xdebug.log


### PR DESCRIPTION
## settings
Add xdebug.ini in apache2/conf.d/ and fpm/conf.d dir.

## HowTo

1. Setting IDE or Editor for listen port 9000 and path mapping.

Example, setteings for Visual Studio Code.

data\wocker\wp-content\\.vscode\launch.json

```
"configurations": [
     {
        "name": "Listen for XDebug",
        "type": "php",
        "request": "launch",
        "port": 9000,
        "pathMappings":{
            "/var/www/wordpress/wp-content":"${workspaceFolder}"
         }
    },
]
```

2. Set break point in IDE.
3. Set mode of IDE to listen XDebug.
3. Start debug session by access `http://wocker.test/?XDEBUG_SESSION_START` or using browser addon.
4. Stop breakpoint.

This screenshot show breaking line 30 in \wp-content\themes\twentytwenty\header.php
![header php - wp-content - Visual Studio Code 2020_04_02 15_51_25](https://user-images.githubusercontent.com/14228487/78219161-ee2fa500-74f9-11ea-8f37-7e352eeb2159.png)

I was cheked break on Visual Studio Code and NeoVim in Windows.